### PR TITLE
Added AA_API so that sns_motor_channel_count can be used outside of SNS

### DIFF
--- a/include/sns/motor.h
+++ b/include/sns/motor.h
@@ -337,7 +337,7 @@ sns_motor_state_get( struct sns_motor_state_set *state_set );
 /**
  * Return the number of channel elements in list
  */
-size_t
+AA_API size_t
 sns_motor_channel_count( struct sns_motor_channel *list );
 
 /**

--- a/src/motor.c
+++ b/src/motor.c
@@ -407,7 +407,7 @@ sns_motor_ref_collate ( const struct timespec *now,
     }
 }
 
-size_t
+AA_API size_t
 sns_motor_channel_count( struct sns_motor_channel *list )
 {
     size_t n = 0;


### PR DESCRIPTION
While developing a realtime driver outside of SNS, I needed access to the sns_motor_channel_count function, but could not compile code referencing it since the function was not tagged with "AA_API". This pull request fixes that issue.

I'm not sure if this was intended to be an internal method, but I can see no reason why it couldn't be a library method, since most of the other methods dealing with sns_motor_channels are library-level.